### PR TITLE
fix expire query

### DIFF
--- a/aiohttp_session_mongo/__init__.py
+++ b/aiohttp_session_mongo/__init__.py
@@ -31,13 +31,11 @@ class MongoStorage(AbstractStorage):
             stored_key = (self.cookie_name + '_' + key).encode('utf-8')
             data_row = await self._collection.find_one(
                 filter={
-                    '$and': [
-                        {'key': stored_key},
-                        {
-                            '$or': [
-                                {'expire': None},
-                                {'expire': {'$lt': datetime.utcnow()}}]
-                        }]
+                    'key': stored_key,
+                    '$or': [
+                        {'expire': None},
+                        {'expire': {'$gt': datetime.utcnow()}}
+                    ]
                 })
 
             if data_row is None:


### PR DESCRIPTION
I suppose the session should have `expire_time` in the future - i.e. not yet expired, NOT in the past - already expired.  Classic mistake, happens often to me too :)

Also you don't have to do `$and` at the top level - it's implicit: https://docs.mongodb.com/manual/reference/operator/query/and/